### PR TITLE
WEB-4325 - 22955 - Sistema está gerando o campo de multa indevidamente.

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
@@ -212,7 +212,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(67, 74, '00000000');
         $this->add(75, 89, Util::formatCnab('9', 0, 15, 2));
         if ($boleto->getMulta() > 0) {
-            $percentualMulta = number_format((($boleto->getMulta() * 100) / $boleto->getValor()), 2);
+            $percentualMulta = number_format(($boleto->getMulta() * 100), 2);
             $this->add(66, 66, '2'); // '2' = Percentual
             $this->add(67, 74, $boleto->getDataVencimento()->format('dmY'));
             $this->add(75, 89, Util::formatCnab('9', $percentualMulta, 15, 2));


### PR DESCRIPTION
[//]: # (jira: "{"jiraIssueId":"20561","updatedAt":"2025-03-24T09:12:25.001-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-4325> - 22955 - Sistema está gerando o campo de multa indevidamente.
> Autor: @giovannidalbello

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*</p>

<p>Sistema está gerando o campo de multa indevidamente.</p>

<p>Multa configurada: 2% <a href="https://prnt.sc/QSXs5r8iI8PQ" class="external-link" rel="nofollow noreferrer">https://prnt.sc/QSXs5r8iI8PQ</a><br/>
Multa na remessa: <a href="https://prnt.sc/fa9v02yZwHwU" class="external-link" rel="nofollow noreferrer">https://prnt.sc/fa9v02yZwHwU</a></p>

<p>Verifique que o percentual de multa sofre alterações conforme o valor do documento. Em um boleto de R$10,00 a multa fica em 2,00%, porém em um boleto de R$9,00 a multa fica em 2,20%. <a href="https://prnt.sc/fa9v02yZwHwU" class="external-link" rel="nofollow noreferrer">https://prnt.sc/fa9v02yZwHwU</a></p>

<p>Seguindo o manual, a multa obrigatoriamente precisa ser gerada em percentual <a href="https://prnt.sc/0r8fX59MB7fe" class="external-link" rel="nofollow noreferrer">https://prnt.sc/0r8fX59MB7fe</a> e com isso, o sistema deve gerar a multa com base no valor inserido na configuração da Conta bancária.</p>

<p>Situação também ocorre no ZWeb.</p>

<p>Efetuei mesmo teste no ClippPro e a multa sempre se mantem com o valor configurado na Conta bancária, não sofrendo alterações conforme o valor do documento.</p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*</p>

<p>Identificar o motivo do percentual de multa sofrer alterações conforme o valor do documento e efetuar ajuste para sempre utilizar o valor de multa configurado na Conta bancária.</p>

<p>*<b>Passos para reproduzir o comportamento</b>*</p>

<p>Acesse o link: <a href="https://clipp360.com.br/#/login" class="external-link" rel="nofollow noreferrer">https://clipp360.com.br/#/login</a><br/>
Efetue login na conta em anexo.<br/>
Acesse o menu Financeiro &gt; Receitas &gt; Gerar arquivos de remessa.<br/>
Selecione o banco Sicredi e efetue geração da remessa conforme a imagem: <a href="https://prnt.sc/gk2lmXdyp3dS" class="external-link" rel="nofollow noreferrer">https://prnt.sc/gk2lmXdyp3dS</a><br/>
Verifique que o percentual da multa sofre alterações conforme o valor do documento.</p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>

<p>Login e manual em anexo.</p>

<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>

<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p>Problema:</p>

<p>Ocorre pois o sistema está recalculando o valor da multa em cima do valor do boleto e este calculo está errado. Alterei para enviar o valor correto. </p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p>Solução:</p>

<p>Ajustado o calculo da geração da remessa para a sicredi. </p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p>Impacto da solução:</p>

<p>Geração de arquivo de remessa sicredi</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p>O que testar:</p>

<p>Zweb:</p>

<ul>
	<li>Cenário do card.</li>
</ul>
</div></div>