### PR TITLE
WEB-5459 - 25058 - Ao tentar gerar arquivos de remessa do Sicredi o ZWeb retorna: Aconteceu um problema com sua ação

### DIFF
--- a/src/Cnab/Remessa/Cnab240/AbstractRemessa.php
+++ b/src/Cnab/Remessa/Cnab240/AbstractRemessa.php
@@ -152,7 +152,7 @@ abstract class AbstractRemessa extends AbstractRemessaGeneric
     public function gerar()
     {
         if (!$this->isValid($messages)) {
-            throw new \Exception('Campos requeridos pelo banco, aparentam estar ausentes ' . $messages);
+            throw new \Exception('Campos requeridos pelo banco não estão preenchidos (' . $messages . '), ajuste e tente novamente.');
         }
 
         $stringRemessa = '';


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"26087","UpdatedAt":"2025-11-10T10:55:24.237-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-5459> - 25058 - Ao tentar gerar arquivos de remessa do Sicredi o ZWeb retorna: Aconteceu um problema com sua ação
> Autor: @vdr3w
> Responsável Teste: @mateus-rosiak

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*</p>

<p>Ao tentar gerar arquivos de remessa do Sicredi o ZWeb retorna: Aconteceu um problema com sua ação, favor entrar em contato com a equipe da Zucchetti.</p>

<p><a href="https://prnt.sc/hwWgyyGaEJ7j" class="external-link" rel="nofollow noreferrer">https://prnt.sc/hwWgyyGaEJ7j</a></p>

<p>Cadastrei em conta interna as mesmas configurações de conta do cliente, situação também ocorreu.</p>

<p>Testei com outras configurações de conta, boleto é gerado normalmente porém no momento de gerar a remessa retorna o mesmo erro.</p>

<p>Verifiquei no sentry retornou: <a href="https://prnt.sc/df_1Ik1dIHCJ" class="external-link" rel="nofollow noreferrer">https://prnt.sc/df_1Ik1dIHCJ</a></p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*</p>

<p>Identificar o motivo de retornar erro ao gerar o arquivo de remessa e corrigir rotina.</p>

<p>*<b>Passos para reproduzir o comportamento</b>*</p>

<p>Acesse o link: <a href="https://zweb.com.br/#/sign-in" class="external-link" rel="nofollow noreferrer">https://zweb.com.br/#/sign-in</a><br/>
Efetue login na conta em anexo.<br/>
Acesse o menu Financeiro &gt; Receitas &gt; Gerar arquivos de remessa.<br/>
Selecione o banco Sicredi e efetue geração da remessa conforme a imagem: <a href="https://prnt.sc/ha2Xa-S8YoWN" class="external-link" rel="nofollow noreferrer">https://prnt.sc/ha2Xa-S8YoWN</a><br/>
Verifique que retorna: <a href="https://prnt.sc/hwWgyyGaEJ7j" class="external-link" rel="nofollow noreferrer">https://prnt.sc/hwWgyyGaEJ7j</a></p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>

<p>Login em anexo.</p>

<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>

<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #ffebe6;border-width: 1px;"><div class="panelContent" style="background-color: #ffebe6;">
<p><b>Problema real (técnico):</b></p>

<p>O problema era o SICREDI pede obrigatoriamente o Numero da Remessa, e nao era obrigatorio em nosso cadastro de conta</p>

<p>Na conta do cliente do card o <tt>Numero da Remessa</tt> estava em branco na conta, entao <tt>Gerar arquivos de remessa</tt> falhava.</p>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p><b>Ajuste realizado:</b></p>

<p>Agora se o banco for SICREDI, o campo Numero da Remessa se torna obrigatorio no cadastro e update de contas.</p>

<p>Tambem foi ajustado na conta em producao do cliente do card com um numero de remessa e o <tt>Gerar arquivos de remessa</tt> funcionou corretamente</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Comportamento esperado: (Caso houver mudança de rotina) * Opcional</b></p>

<p>Mesma rotina do card, mas agora, com o numero de remessa preenchido, vai funcionar corretamente.</p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p><b>Sugestão de testes:</b></p>

<p>Conselho pra testar: Crie uma conta Sicredi SEM NUMERO DE REMESSA, antes de entrar na branch, pois apos entrar, vai bloquear o cadastro, e com essa conta tente gerar o arquivo de remessa, vai falhar, adicione o numero de remessa (agora obrigatorio para SICREDI) e tente novamente, deve ocorrer sem erros</p>
</div></div>